### PR TITLE
Add read the docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: '3.9'
+
+python:
+  install:
+    - requirements: 'docs/requirements.txt'
+
+sphinx:
+  configuration: 'docs/conf.py'
+  fail_on_warning: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==4.4.0
+sphinx-rtd-theme==1.0.0
+sphinxcontrib-bibtex==2.4.1


### PR DESCRIPTION
Added read the docs configuration file and requirements. @firefly-cpp You can set up the account and link the repository as described in [this tutorial](https://docs.readthedocs.io/en/stable/tutorial/).

Closes #30 