### PR TITLE
Fix division by zero error during acc calculation

### DIFF
--- a/niaarm/rule.py
+++ b/niaarm/rule.py
@@ -221,9 +221,8 @@ class Rule:
             if attribute.dtype != "cat":
                 feature_min = min_[attribute.name]
                 feature_max = max_[attribute.name]
-                acc += (attribute.max_val - attribute.min_val) / (
-                    feature_max - feature_min
-                )
+                acc += 1 if feature_max == feature_min \
+                    else (attribute.max_val - attribute.min_val) / (feature_max - feature_min)
                 contains_antecedent &= transactions[attribute.name] <= attribute.max_val
                 contains_antecedent &= transactions[attribute.name] >= attribute.min_val
             else:
@@ -240,9 +239,8 @@ class Rule:
             if attribute.dtype != "cat":
                 feature_min = min_[attribute.name]
                 feature_max = max_[attribute.name]
-                acc += (attribute.max_val - attribute.min_val) / (
-                    feature_max - feature_min
-                )
+                acc += 1 if feature_max == feature_min \
+                    else (attribute.max_val - attribute.min_val) / (feature_max - feature_min)
                 contains_consequent &= transactions[attribute.name] <= attribute.max_val
                 contains_consequent &= transactions[attribute.name] >= attribute.min_val
             else:


### PR DESCRIPTION
This pull request is relevant to the following issue: https://github.com/firefly-cpp/NiaARM/issues/112.

In `rule.py`, while calculating `acc` as part of `amplitude` rule quality criterion, the code throws a `division by zero` warning if the `feature_max == feature_min`.

In that case, `acc` is increased by one, instead of the division.