### PR TITLE
Add Leverage Rule Quality Criterion

### DIFF
--- a/interest_measures.md
+++ b/interest_measures.md
@@ -208,3 +208,18 @@ and 0 reflects independence)
 
 **Reference:** T. Zhang, “Association Rules,” in Knowledge Discovery and Data Mining. Current Issues and New 
 Applications, 2000, pp. 245–256. doi: 10.1007/3-540-45571-X_31. 
+
+## Leverage
+
+Leverage metric is difference between the frequency of antecedent and the consequent appearing together and the expected
+frequency of them appearing separately based on their individual support
+
+```math
+leverage(X \implies Y) = support(X \implies Y) - (support(X) \times support(Y))
+```
+
+**Range:** `[-1, 1]` (-1 reflects total negative association, 1 reflects perfect positive association
+and 0 reflects independence)
+
+**Reference:** Gregory Piatetsky-Shapiro. 1991. Discovery, Analysis, and Presentation of Strong Rules. In
+Knowledge Discovery in Databases, Gregory Piatetsky-Shapiro and William J. Frawley (Eds.). AAAI/MIT Press, 229–248.

--- a/niaarm/rule.py
+++ b/niaarm/rule.py
@@ -156,6 +156,16 @@ class Rule:
          **Reference:** T. Zhang, “Association Rules,” in Knowledge Discovery and Data Mining. Current Issues and New
          Applications, 2000, pp. 245–256. doi: 10.1007/3-540-45571-X_31.
 
+        leverage: difference between the frequency of antecedent and the consequent appearing together and the expected
+        frequency of them appearing separately based on their individual support
+
+        :math: `leverage(X \implies Y) = support(X \implies Y) - (support(X) \times support(Y))`
+
+        **Range:** :math: `[-1, 1]` (-1 reflects total negative association, 1 reflects perfect positive association
+         and 0 reflects independence)
+
+        **Reference:** Gregory Piatetsky-Shapiro. 1991. Discovery, Analysis, and Presentation of Strong Rules. In
+        Knowledge Discovery in Databases, Gregory Piatetsky-Shapiro and William J. Frawley (Eds.). AAAI/MIT Press, 229–248.
     """
 
     __slots__ = (
@@ -326,6 +336,11 @@ class Rule:
         )
 
         return numerator / denominator
+
+    @property
+    def leverage(self):
+        return self.support - (
+                (self.antecedent_count / self.num_transactions) * (self.consequent_count / self.num_transactions))
 
     def __eq__(self, other):
         return (

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -70,3 +70,7 @@ class TestMetrics(TestCase):
     def test_zhang(self):
         self.assertAlmostEqual(self.rule_one.zhang, 5 / 9)
         self.assertAlmostEqual(self.rule_two.zhang, 5 / 8)
+
+    def test_leverage(self):
+        self.assertAlmostEqual(self.rule_one.leverage, 0.102040816326)
+        self.assertAlmostEqual(self.rule_two.leverage, 0.102040816326)


### PR DESCRIPTION
Leverage is one of the commonly used rule quality criteria, and it was lacking in the library. I added the implementation, together with unit tests, documentation, and references. 